### PR TITLE
fix: public NPM access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
@@ -123,6 +124,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_pypi:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,7 +1,7 @@
 import { ProjenStruct, Struct } from "@mrgrain/jsii-struct-builder";
 import { awscdk, ReleasableCommits } from "projen";
 import { GithubCredentials } from "projen/lib/github";
-import { ProseWrap } from "projen/lib/javascript";
+import { NpmAccess, ProseWrap } from "projen/lib/javascript";
 
 const project = new awscdk.AwsCdkConstructLibrary({
   author: "Ben Limmer",
@@ -22,6 +22,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   jsiiVersion: "~5.7.0",
 
   releasableCommits: ReleasableCommits.featuresAndFixes(), // don't release "chore" commits
+  npmAccess: NpmAccess.PUBLIC,
   python: {
     distName: "cdk-github-oidc",
     module: "cdk_github_oidc",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "coverageProvider": "v8",


### PR DESCRIPTION
Since the NPM package is namespaced under `@blimmer`, the release failed. I need to explicitly mark public access.