### PR TITLE
feat: support GitHub's immutable OIDC subject claims

### DIFF
--- a/API.md
+++ b/API.md
@@ -1478,6 +1478,8 @@ const branchFilterProps: BranchFilterProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@blimmer/cdk-github-oidc.BranchFilterProps.property.owner">owner</a></code> | <code>string</code> | The org or user that owns the repository. |
 | <code><a href="#@blimmer/cdk-github-oidc.BranchFilterProps.property.repository">repository</a></code> | <code>string</code> | The name of the repository. |
+| <code><a href="#@blimmer/cdk-github-oidc.BranchFilterProps.property.ownerId">ownerId</a></code> | <code>string</code> | The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format. |
+| <code><a href="#@blimmer/cdk-github-oidc.BranchFilterProps.property.repositoryId">repositoryId</a></code> | <code>string</code> | The numeric ID of the repository, used by GitHub's immutable subject claim format. |
 | <code><a href="#@blimmer/cdk-github-oidc.BranchFilterProps.property.branch">branch</a></code> | <code>string</code> | The name of the branch to filter on. You can also use wildcards. |
 
 ---
@@ -1503,6 +1505,37 @@ public readonly repository: string;
 - *Type:* string
 
 The name of the repository.
+
+---
+
+##### `ownerId`<sup>Optional</sup> <a name="ownerId" id="@blimmer/cdk-github-oidc.BranchFilterProps.property.ownerId"></a>
+
+```typescript
+public readonly ownerId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `repositoryId`. Find it via
+`gh api repos/OWNER/REPO --jq .owner.id`.
+
+---
+
+##### `repositoryId`<sup>Optional</sup> <a name="repositoryId" id="@blimmer/cdk-github-oidc.BranchFilterProps.property.repositoryId"></a>
+
+```typescript
+public readonly repositoryId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
 
 ---
 
@@ -1536,6 +1569,8 @@ const customFilterProps: CustomFilterProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@blimmer/cdk-github-oidc.CustomFilterProps.property.owner">owner</a></code> | <code>string</code> | The org or user that owns the repository. |
 | <code><a href="#@blimmer/cdk-github-oidc.CustomFilterProps.property.repository">repository</a></code> | <code>string</code> | The name of the repository. |
+| <code><a href="#@blimmer/cdk-github-oidc.CustomFilterProps.property.ownerId">ownerId</a></code> | <code>string</code> | The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format. |
+| <code><a href="#@blimmer/cdk-github-oidc.CustomFilterProps.property.repositoryId">repositoryId</a></code> | <code>string</code> | The numeric ID of the repository, used by GitHub's immutable subject claim format. |
 | <code><a href="#@blimmer/cdk-github-oidc.CustomFilterProps.property.filter">filter</a></code> | <code>string</code> | The filter to apply. The construct will automatically prefix the filter with `repo:${owner}/${repository}:`. |
 
 ---
@@ -1561,6 +1596,37 @@ public readonly repository: string;
 - *Type:* string
 
 The name of the repository.
+
+---
+
+##### `ownerId`<sup>Optional</sup> <a name="ownerId" id="@blimmer/cdk-github-oidc.CustomFilterProps.property.ownerId"></a>
+
+```typescript
+public readonly ownerId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `repositoryId`. Find it via
+`gh api repos/OWNER/REPO --jq .owner.id`.
+
+---
+
+##### `repositoryId`<sup>Optional</sup> <a name="repositoryId" id="@blimmer/cdk-github-oidc.CustomFilterProps.property.repositoryId"></a>
+
+```typescript
+public readonly repositoryId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
 
 ---
 
@@ -1594,6 +1660,8 @@ const environmentFilterProps: EnvironmentFilterProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.owner">owner</a></code> | <code>string</code> | The org or user that owns the repository. |
 | <code><a href="#@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.repository">repository</a></code> | <code>string</code> | The name of the repository. |
+| <code><a href="#@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.ownerId">ownerId</a></code> | <code>string</code> | The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format. |
+| <code><a href="#@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.repositoryId">repositoryId</a></code> | <code>string</code> | The numeric ID of the repository, used by GitHub's immutable subject claim format. |
 | <code><a href="#@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.environment">environment</a></code> | <code>string</code> | The name of the Github environment to allow assuming this role. |
 
 ---
@@ -1619,6 +1687,37 @@ public readonly repository: string;
 - *Type:* string
 
 The name of the repository.
+
+---
+
+##### `ownerId`<sup>Optional</sup> <a name="ownerId" id="@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.ownerId"></a>
+
+```typescript
+public readonly ownerId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `repositoryId`. Find it via
+`gh api repos/OWNER/REPO --jq .owner.id`.
+
+---
+
+##### `repositoryId`<sup>Optional</sup> <a name="repositoryId" id="@blimmer/cdk-github-oidc.EnvironmentFilterProps.property.repositoryId"></a>
+
+```typescript
+public readonly repositoryId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
 
 ---
 
@@ -1650,6 +1749,8 @@ const githubActionOidcFilterProps: GithubActionOidcFilterProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.owner">owner</a></code> | <code>string</code> | The org or user that owns the repository. |
 | <code><a href="#@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.repository">repository</a></code> | <code>string</code> | The name of the repository. |
+| <code><a href="#@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.ownerId">ownerId</a></code> | <code>string</code> | The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format. |
+| <code><a href="#@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.repositoryId">repositoryId</a></code> | <code>string</code> | The numeric ID of the repository, used by GitHub's immutable subject claim format. |
 
 ---
 
@@ -1674,6 +1775,37 @@ public readonly repository: string;
 - *Type:* string
 
 The name of the repository.
+
+---
+
+##### `ownerId`<sup>Optional</sup> <a name="ownerId" id="@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.ownerId"></a>
+
+```typescript
+public readonly ownerId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `repositoryId`. Find it via
+`gh api repos/OWNER/REPO --jq .owner.id`.
+
+---
+
+##### `repositoryId`<sup>Optional</sup> <a name="repositoryId" id="@blimmer/cdk-github-oidc.GithubActionOidcFilterProps.property.repositoryId"></a>
+
+```typescript
+public readonly repositoryId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
 
 ---
 
@@ -2224,6 +2356,8 @@ const tagFilterProps: TagFilterProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@blimmer/cdk-github-oidc.TagFilterProps.property.owner">owner</a></code> | <code>string</code> | The org or user that owns the repository. |
 | <code><a href="#@blimmer/cdk-github-oidc.TagFilterProps.property.repository">repository</a></code> | <code>string</code> | The name of the repository. |
+| <code><a href="#@blimmer/cdk-github-oidc.TagFilterProps.property.ownerId">ownerId</a></code> | <code>string</code> | The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format. |
+| <code><a href="#@blimmer/cdk-github-oidc.TagFilterProps.property.repositoryId">repositoryId</a></code> | <code>string</code> | The numeric ID of the repository, used by GitHub's immutable subject claim format. |
 | <code><a href="#@blimmer/cdk-github-oidc.TagFilterProps.property.tag">tag</a></code> | <code>string</code> | The name of the tag to filter on. You can also use wildcards. |
 
 ---
@@ -2249,6 +2383,37 @@ public readonly repository: string;
 - *Type:* string
 
 The name of the repository.
+
+---
+
+##### `ownerId`<sup>Optional</sup> <a name="ownerId" id="@blimmer/cdk-github-oidc.TagFilterProps.property.ownerId"></a>
+
+```typescript
+public readonly ownerId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `repositoryId`. Find it via
+`gh api repos/OWNER/REPO --jq .owner.id`.
+
+---
+
+##### `repositoryId`<sup>Optional</sup> <a name="repositoryId" id="@blimmer/cdk-github-oidc.TagFilterProps.property.repositoryId"></a>
+
+```typescript
+public readonly repositoryId: string;
+```
+
+- *Type:* string
+- *Default:* the subject uses the previous (name-only) format
+
+The numeric ID of the repository, used by GitHub's immutable subject claim format.
+
+Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ OIDC (OpenID Connect) allows GitHub Actions to authenticate directly with AWS us
 storing AWS credentials. The process is described in
 [GitHub's documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect).
 
-## Security Benefits
-
-Using OIDC for GitHub Actions authentication:
+<details>
+<summary>Why use OIDC instead of access keys?</summary>
 
 - Eliminates the need to store AWS credentials as GitHub secrets
 - Provides short-lived, automatically rotated credentials
 - Enables fine-grained access control based on repository, branch, environment, or other conditions
 - Follows security best practices for cloud access
+
+</details>
 
 ## Installation
 
@@ -38,7 +39,9 @@ yarn add @blimmer/cdk-github-oidc
 pip install cdk-github-oidc
 ```
 
-For Python, see [below](#python).
+## Usage
+
+The examples below are TypeScript. For the full API in every supported language, see [API.md](/API.md).
 
 ### Create or Import a Provider
 
@@ -91,18 +94,30 @@ export class MyStack extends Stack {
       provider,
       roleName: "my-github-actions-role",
       description: "Role assumed by GitHub Actions",
-      subjectFilters: [new BranchFilter({ owner: "blimmer", repository: "cdk-github-oidc", branch: "*" })],
+      subjectFilters: [
+        new BranchFilter({
+          owner: "blimmer",
+          ownerId: "630449",
+          repository: "cdk-github-oidc",
+          repositoryId: "919628491",
+          branch: "*",
+        }),
+      ],
     });
   }
 }
 ```
+
+`ownerId` and `repositoryId` opt into GitHub's [immutable subject claims](#immutable-subject-claims), the default for
+repositories created after July 15, 2026. Omit both if your repository predates that.
 
 ### Subject Filters
 
 You must pass one or more `SubjectFilter`s to the `GithubActionsRole` construct. These filters are used to determine
 which GitHub Actions workflows can assume the role.
 
-This construct exposes first class support for the following filters:
+This construct exposes first class support for the following filters. The examples omit `ownerId` and `repositoryId` to
+keep the focus on what each filter does; add them as shown above if your repository uses immutable subject claims.
 
 - [`AllowAllFilter`](/API.md#allowallfilter)
 
@@ -196,8 +211,126 @@ If none of these filters fit your use case, you can implement your own via the
 [`IGithubActionOidcFilter`](/API.md#igithubactionoidcfilter) interface, or use the
 [`CustomFilter`](/API.md#customfilter) construct.
 
+When writing your own, build the subject from the protected `repositoryClaim` getter rather than from `owner` and
+`repository` directly. It renders whichever `repo:` prefix the filter was configured for, so your filter keeps working
+if the repository moves to [immutable subject claims](#immutable-subject-claims).
+
+```ts
+class DeploymentFilter extends IGithubActionOidcFilter {
+  public toSubject(): string {
+    return `${this.repositoryClaim}:deployment`;
+  }
+}
+```
+
 You can learn more about subject filters in the
 [Github docs](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#configuring-the-subject-in-your-cloud-provider)
+
+### Immutable Subject Claims
+
+GitHub is moving to an
+[immutable subject claim format](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims)
+that embeds numeric owner and repository IDs:
+
+```
+repo:blimmer/cdk-github-oidc:ref:refs/heads/main                   # previous
+repo:blimmer@630449/cdk-github-oidc@919628491:ref:refs/heads/main  # immutable
+```
+
+Repositories created after July 15, 2026 use the immutable format, as do repositories renamed or transferred after that
+date. Everything else keeps the previous format until you opt in, per repo or per org, in the OIDC settings UI or the
+[REST API](https://docs.github.com/en/rest/actions/oidc). A repository emits one format or the other, never both.
+
+Pass `ownerId` and `repositoryId` to any filter to get the immutable format:
+
+```ts
+new BranchFilter({
+  owner: "blimmer",
+  ownerId: "630449",
+  repository: "cdk-github-oidc",
+  repositoryId: "919628491",
+  branch: "main",
+});
+```
+
+Leave them off and you get the previous format, which is what the [subject filter](#subject-filters) examples above do.
+
+#### Finding the IDs
+
+```sh
+gh api repos/OWNER/REPO --jq '{ownerId: .owner.id, repositoryId: .id}'
+```
+
+To check which format a repository emits right now, read `sub_claim_prefix`:
+
+```sh
+gh api repos/OWNER/REPO/actions/oidc/customization/sub
+# {"use_default":true,"use_immutable_subject":false,"sub_claim_prefix":"repo:blimmer/cdk-github-oidc"}
+```
+
+The same setting lives at `https://github.com/OWNER/REPO/settings/actions/oidc-configuration`.
+
+#### Migration Prompt
+
+If you have more than a couple of filters, hand this to your coding agent.
+
+<details>
+<summary>Show the prompt</summary>
+
+```text
+Upgrade `@blimmer/cdk-github-oidc` to the latest version, then audit this CDK app for GitHub's immutable OIDC
+subject claim format.
+
+Background: GitHub embeds numeric owner and repository IDs in the OIDC `sub` claim
+(`repo:owner@123/repo@456:ref:refs/heads/main` instead of `repo:owner/repo:ref:refs/heads/main`). Repositories
+created, renamed, or transferred after July 15, 2026 use it automatically. Older repositories keep the previous
+format until someone opts in. A repository emits one format or the other, never both, so a trust policy built for
+the wrong format fails with `Not authorized to perform sts:AssumeRoleWithWebIdentity`.
+
+For every subject filter passed to a `GithubActionsRole` in this app:
+
+1. Run `gh api repos/<owner>/<repository>/actions/oidc/customization/sub` and read `use_immutable_subject`.
+2. If it is `false`, leave the filter alone. It is already correct.
+3. If it is `true`, run `gh api repos/<owner>/<repository> --jq '{ownerId: .owner.id, repositoryId: .id}'` and add
+   both values to that filter as `ownerId` and `repositoryId` (strings, not numbers). Keep `owner` and
+   `repository` as the plain names.
+
+Then find every class in this app that extends `IGithubActionOidcFilter`. If its `toSubject()` builds the subject
+from `this.owner` and `this.repository`, rewrite it to use the `this.repositoryClaim` getter instead, leaving the
+rest of the subject unchanged. Custom filters that skip this keep emitting the previous format no matter which IDs
+are passed to them.
+
+Report any repository the `gh` calls fail for rather than guessing its IDs, since a wrong ID produces a role nobody
+can assume. Do not add, remove, or re-scope any filter, and do not change anything beyond the filter arguments and
+the custom filter subject construction.
+```
+
+</details>
+
+#### Switching an Existing Repository
+
+Add a second filter carrying the IDs, deploy, opt in on GitHub, then delete the original filter. The role trusts both
+subjects in between, so nothing breaks mid-switch.
+
+```ts
+subjectFilters: [
+  new BranchFilter({ owner: "blimmer", repository: "cdk-github-oidc", branch: "main" }),
+  new BranchFilter({
+    owner: "blimmer",
+    ownerId: "630449",
+    repository: "cdk-github-oidc",
+    repositoryId: "919628491",
+    branch: "main",
+  }),
+];
+```
+
+Double-check the IDs. A wrong one produces a subject that never matches, and the only symptom is
+`Not authorized to perform sts:AssumeRoleWithWebIdentity`.
+
+Don't reach for a wildcard like `blimmer@*` to avoid looking them up. That trusts every account named `blimmer`,
+including whoever claims the name if the current owner renames or deletes it. Preventing exactly that is why the IDs
+exist.
 
 ### Granting Permissions to the Role
 
@@ -267,27 +400,28 @@ jobs:
 See [the `aws-actions/configure-aws-credentials` docs](https://github.com/aws-actions/configure-aws-credentials) for
 more details.
 
-## Usage
-
-For detailed API docs, see [API.md](/API.md).
-
 ## Troubleshooting
 
 ### Common Issues
 
 1. **Role assumption fails**: Ensure your GitHub Action has the required permissions:
 
-```yaml
-permissions:
-  id-token: write # Required for OIDC
-  contents: read # Required for checking out code
-```
+   ```yaml
+   permissions:
+     id-token: write # Required for OIDC
+     contents: read # Required for checking out code
+   ```
 
 1. **Provider already exists**: Only one OIDC provider can exist per AWS account. Use
    `GithubActionsIdentityProvider.fromAccount()` if one already exists.
 
 1. **Subject filter not matching**: Double check your subject filter configuration matches your GitHub workflow context.
    Use logging to debug the actual subject string being provided.
+
+1. **Role assumption breaks after a repo is created, renamed, or transferred**: the repository probably switched to
+   [immutable subject claims](#immutable-subject-claims). Run `gh api repos/OWNER/REPO/actions/oidc/customization/sub`
+   to see which format it emits, and pass `ownerId` and `repositoryId` to your filters if `use_immutable_subject` is
+   `true`. CloudTrail shows the subject that was actually presented.
 
 ## Migrating from `aws-cdk-github-oidc`
 

--- a/src/GithubActionsRole.ts
+++ b/src/GithubActionsRole.ts
@@ -43,7 +43,7 @@ export class GithubActionsRole extends Role {
 
     if (subjectFilters.length === 0) {
       throw new Error(
-        "You must provide at least one subject filter. Consider a BranchFilter allowing all (`*`) branches. See the docs for more information: https://github.com/blimmer/cdk-github-oidc/README.md",
+        "You must provide at least one subject filter. Consider a BranchFilter allowing all (`*`) branches. See the docs for more information: https://github.com/blimmer/cdk-github-oidc#subject-filters",
       );
     }
 

--- a/src/filters/AllowAllFilter.ts
+++ b/src/filters/AllowAllFilter.ts
@@ -5,6 +5,6 @@ import { IGithubActionOidcFilter } from "./IGithubActionOidcFilter";
  */
 export class AllowAllFilter extends IGithubActionOidcFilter {
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:*`;
+    return `${this.repositoryClaim}:*`;
   }
 }

--- a/src/filters/BranchFilter.ts
+++ b/src/filters/BranchFilter.ts
@@ -25,6 +25,6 @@ export class BranchFilter extends IGithubActionOidcFilter {
   }
 
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:ref:refs/heads/${this.branch}`;
+    return `${this.repositoryClaim}:ref:refs/heads/${this.branch}`;
   }
 }

--- a/src/filters/CustomFilter.ts
+++ b/src/filters/CustomFilter.ts
@@ -25,6 +25,6 @@ export class CustomFilter extends IGithubActionOidcFilter {
   }
 
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:${this.filter}`;
+    return `${this.repositoryClaim}:${this.filter}`;
   }
 }

--- a/src/filters/EnvironmentFilter.ts
+++ b/src/filters/EnvironmentFilter.ts
@@ -21,6 +21,6 @@ export class EnvironmentFilter extends IGithubActionOidcFilter {
   }
 
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:environment:${this.environment}`;
+    return `${this.repositoryClaim}:environment:${this.environment}`;
   }
 }

--- a/src/filters/IGithubActionOidcFilter.ts
+++ b/src/filters/IGithubActionOidcFilter.ts
@@ -1,9 +1,30 @@
+const DOCS_URL = "https://github.com/blimmer/cdk-github-oidc#immutable-subject-claims";
+
 export interface GithubActionOidcFilterProps {
   /** The org or user that owns the repository */
   readonly owner: string;
 
   /** The name of the repository */
   readonly repository: string;
+
+  /**
+   * The numeric ID of the org or user that owns the repository, used by GitHub's immutable subject claim format.
+   *
+   * Must be provided together with `repositoryId`. Find it via
+   * `gh api repos/OWNER/REPO --jq .owner.id`.
+   *
+   * @default - the subject uses the previous (name-only) format
+   */
+  readonly ownerId?: string;
+
+  /**
+   * The numeric ID of the repository, used by GitHub's immutable subject claim format.
+   *
+   * Must be provided together with `ownerId`. Find it via `gh api repos/OWNER/REPO --jq .id`.
+   *
+   * @default - the subject uses the previous (name-only) format
+   */
+  readonly repositoryId?: string;
 }
 
 /**
@@ -14,10 +35,50 @@ export interface GithubActionOidcFilterProps {
 export abstract class IGithubActionOidcFilter {
   protected readonly owner: string;
   protected readonly repository: string;
+  protected readonly ownerId?: string;
+  protected readonly repositoryId?: string;
 
   constructor(props: GithubActionOidcFilterProps) {
+    if (props.ownerId === "" || props.repositoryId === "") {
+      throw new Error(
+        `\`ownerId\` and \`repositoryId\` must not be empty strings. Omit both to build a subject like \`repo:owner/repo:...\`, or pass both to build one like \`repo:owner@123/repo@456:...\`. See ${DOCS_URL}`,
+      );
+    }
+
+    if ((props.ownerId === undefined) !== (props.repositoryId === undefined)) {
+      throw new Error(
+        `\`ownerId\` and \`repositoryId\` must be provided together. GitHub's immutable subject claim looks like \`repo:owner@123/repo@456:...\`, so a subject built from only one ID can never match. See ${DOCS_URL}`,
+      );
+    }
+
+    if (props.ownerId !== undefined && props.owner.includes("@")) {
+      throw new Error(
+        `\`owner\` must not contain \`@\` when \`ownerId\` is provided, or the ID is applied twice (\`owner@123@123\`). Pass the plain owner name. See ${DOCS_URL}`,
+      );
+    }
+
+    if (props.repositoryId !== undefined && props.repository.includes("@")) {
+      throw new Error(
+        `\`repository\` must not contain \`@\` when \`repositoryId\` is provided, or the ID is applied twice (\`repo@456@456\`). Pass the plain repository name. See ${DOCS_URL}`,
+      );
+    }
+
     this.owner = props.owner;
     this.repository = props.repository;
+    this.ownerId = props.ownerId;
+    this.repositoryId = props.repositoryId;
+  }
+
+  /**
+   * The `repo:` prefix shared by every subject claim, in whichever format this filter was configured for.
+   *
+   * Use this instead of building the prefix by hand so your filter works with both the previous and the immutable
+   * subject claim formats.
+   */
+  protected get repositoryClaim(): string {
+    const owner = this.ownerId === undefined ? this.owner : `${this.owner}@${this.ownerId}`;
+    const repository = this.repositoryId === undefined ? this.repository : `${this.repository}@${this.repositoryId}`;
+    return `repo:${owner}/${repository}`;
   }
 
   public abstract toSubject(): string;

--- a/src/filters/PullRequestFilter.ts
+++ b/src/filters/PullRequestFilter.ts
@@ -7,6 +7,6 @@ import { IGithubActionOidcFilter } from "./IGithubActionOidcFilter";
  */
 export class PullRequestFilter extends IGithubActionOidcFilter {
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:pull_request`;
+    return `${this.repositoryClaim}:pull_request`;
   }
 }

--- a/src/filters/TagFilter.ts
+++ b/src/filters/TagFilter.ts
@@ -25,6 +25,6 @@ export class TagFilter extends IGithubActionOidcFilter {
   }
 
   public toSubject(): string {
-    return `repo:${this.owner}/${this.repository}:ref:refs/tags/${this.tag}`;
+    return `${this.repositoryClaim}:ref:refs/tags/${this.tag}`;
   }
 }

--- a/test/GithubActionsRole.test.ts
+++ b/test/GithubActionsRole.test.ts
@@ -73,7 +73,7 @@ describe("GithubActionsRole", () => {
     expect(() => {
       new GithubActionsRole(stack, "Role", { provider, subjectFilters: [] });
     }).toThrow(
-      "You must provide at least one subject filter. Consider a BranchFilter allowing all (`*`) branches. See the docs for more information: https://github.com/blimmer/cdk-github-oidc/README.md",
+      "You must provide at least one subject filter. Consider a BranchFilter allowing all (`*`) branches. See the docs for more information: https://github.com/blimmer/cdk-github-oidc#subject-filters",
     );
   });
 
@@ -132,6 +132,49 @@ describe("GithubActionsRole", () => {
                 "token.actions.githubusercontent.com:sub": [
                   "repo:my-org/my-repo:ref:refs/heads/main",
                   "repo:my-org/my-repo:ref:refs/heads/staging",
+                ],
+              },
+            },
+            Effect: "Allow",
+            Principal: {
+              Federated: "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("handles a mix of previous-format and immutable-format filters", () => {
+    const app = new App();
+    const stack = new Stack(app, "Stack");
+    const provider = GithubActionsIdentityProvider.fromAccount(stack, { account: "123456789012", partition: "aws" });
+    new GithubActionsRole(stack, "Role", {
+      provider,
+      subjectFilters: [
+        new BranchFilter({ owner: "my-org", repository: "my-repo", branch: "main" }),
+        new BranchFilter({
+          owner: "my-org",
+          ownerId: "630449",
+          repository: "my-repo",
+          repositoryId: "919628491",
+          branch: "main",
+        }),
+      ],
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::IAM::Role", {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: "sts:AssumeRoleWithWebIdentity",
+            Condition: {
+              StringEquals: {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub": [
+                  "repo:my-org/my-repo:ref:refs/heads/main",
+                  "repo:my-org@630449/my-repo@919628491:ref:refs/heads/main",
                 ],
               },
             },

--- a/test/filters/AllowAllFilter.test.ts
+++ b/test/filters/AllowAllFilter.test.ts
@@ -5,4 +5,14 @@ describe("AllowAllFilter", () => {
     const filter = new AllowAllFilter({ owner: "my-org", repository: "my-repo" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:*");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new AllowAllFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:*");
+  });
 });

--- a/test/filters/BranchFilter.test.ts
+++ b/test/filters/BranchFilter.test.ts
@@ -10,4 +10,15 @@ describe("BranchFilter", () => {
     const filter = new BranchFilter({ owner: "my-org", repository: "my-repo", branch: "*" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:ref:refs/heads/*");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new BranchFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+      branch: "main",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:ref:refs/heads/main");
+  });
 });

--- a/test/filters/CustomFilter.test.ts
+++ b/test/filters/CustomFilter.test.ts
@@ -5,4 +5,15 @@ describe("CustomFilter", () => {
     const filter = new CustomFilter({ owner: "my-org", repository: "my-repo", filter: "something_new" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:something_new");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new CustomFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+      filter: "something_new",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:something_new");
+  });
 });

--- a/test/filters/EnvironmentFilter.test.ts
+++ b/test/filters/EnvironmentFilter.test.ts
@@ -5,4 +5,15 @@ describe("EnvironmentFilter", () => {
     const filter = new EnvironmentFilter({ owner: "my-org", repository: "my-repo", environment: "production" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:environment:production");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new EnvironmentFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+      environment: "production",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:environment:production");
+  });
 });

--- a/test/filters/IGithubActionOidcFilter.test.ts
+++ b/test/filters/IGithubActionOidcFilter.test.ts
@@ -1,0 +1,57 @@
+import { BranchFilter } from "../../src";
+
+describe("IGithubActionOidcFilter", () => {
+  it("throws if ownerId is an empty string", () => {
+    expect(() => {
+      new BranchFilter({
+        owner: "my-org",
+        ownerId: "",
+        repository: "my-repo",
+        repositoryId: "919628491",
+        branch: "main",
+      });
+    }).toThrow("`ownerId` and `repositoryId` must not be empty strings.");
+  });
+
+  it("throws if repositoryId is an empty string", () => {
+    expect(() => {
+      new BranchFilter({ owner: "my-org", ownerId: "630449", repository: "my-repo", repositoryId: "", branch: "main" });
+    }).toThrow("`ownerId` and `repositoryId` must not be empty strings.");
+  });
+
+  it("throws if only ownerId is provided", () => {
+    expect(() => {
+      new BranchFilter({ owner: "my-org", ownerId: "630449", repository: "my-repo", branch: "main" });
+    }).toThrow("`ownerId` and `repositoryId` must be provided together.");
+  });
+
+  it("throws if only repositoryId is provided", () => {
+    expect(() => {
+      new BranchFilter({ owner: "my-org", repository: "my-repo", repositoryId: "919628491", branch: "main" });
+    }).toThrow("`ownerId` and `repositoryId` must be provided together.");
+  });
+
+  it("throws if owner already contains the ID", () => {
+    expect(() => {
+      new BranchFilter({
+        owner: "my-org@630449",
+        ownerId: "630449",
+        repository: "my-repo",
+        repositoryId: "919628491",
+        branch: "main",
+      });
+    }).toThrow("`owner` must not contain `@` when `ownerId` is provided");
+  });
+
+  it("throws if repository already contains the ID", () => {
+    expect(() => {
+      new BranchFilter({
+        owner: "my-org",
+        ownerId: "630449",
+        repository: "my-repo@919628491",
+        repositoryId: "919628491",
+        branch: "main",
+      });
+    }).toThrow("`repository` must not contain `@` when `repositoryId` is provided");
+  });
+});

--- a/test/filters/PullRequestFilter.test.ts
+++ b/test/filters/PullRequestFilter.test.ts
@@ -5,4 +5,14 @@ describe("PullRequestFilter", () => {
     const filter = new PullRequestFilter({ owner: "my-org", repository: "my-repo" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:pull_request");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new PullRequestFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:pull_request");
+  });
 });

--- a/test/filters/TagFilter.test.ts
+++ b/test/filters/TagFilter.test.ts
@@ -10,4 +10,15 @@ describe("TagFilter", () => {
     const filter = new TagFilter({ owner: "my-org", repository: "my-repo", tag: "*" });
     expect(filter.toSubject()).toEqual("repo:my-org/my-repo:ref:refs/tags/*");
   });
+
+  it("creates the expected subject filter using immutable subject claims", () => {
+    const filter = new TagFilter({
+      owner: "my-org",
+      ownerId: "630449",
+      repository: "my-repo",
+      repositoryId: "919628491",
+      tag: "v1.0.0",
+    });
+    expect(filter.toSubject()).toEqual("repo:my-org@630449/my-repo@919628491:ref:refs/tags/v1.0.0");
+  });
 });


### PR DESCRIPTION
## Summary

GitHub now embeds numeric owner and repository IDs in the OIDC `sub` claim:

```
repo:blimmer/cdk-github-oidc:ref:refs/heads/main                   # previous
repo:blimmer@630449/cdk-github-oidc@919628491:ref:refs/heads/main  # immutable
```

Repositories created, renamed, or transferred after July 15, 2026 use the immutable format automatically. Older ones keep the previous format until someone opts in, per repo or per org. A repository emits one format or the other, never both, so a trust policy built for the wrong one fails with `Not authorized to perform sts:AssumeRoleWithWebIdentity` and nothing more useful than that.

Every filter currently hardcodes `repo:${owner}/${repository}:`, so a role generated for a post-cutover repository can never match.

See [GitHub's docs](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims).

## Design

Optional `ownerId` and `repositoryId` on the shared `GithubActionOidcFilterProps`. Supplying them is the switch. There's no other way to produce the immutable subject, and no reason to supply the IDs unless you want it, so there's no format enum.

| `ownerId` / `repositoryId` | emitted `repo` segment |
| --- | --- |
| omitted (default) | `repo:owner/repository` |
| both supplied | `repo:owner@ID/repository@ID` |
| exactly one supplied | throws |

Because they live on the base props interface, all six filters pick this up with a one-line change each, and two useful behaviors come along for free:

- A role can serve repos in different states. One filter per repo, some with IDs, some without. All the subjects land in the same `sub` array, which is an OR.
- Switching a repo over needs no dedicated API. Pass two filters for the same repo, deploy, opt in on GitHub, then drop the ID-less one.

A new protected `repositoryClaim` getter owns the whole `repo:` prefix. Custom filters should build subjects from it instead of from `owner` and `repository` directly, or they'll keep emitting the previous format no matter which IDs they get.

The IDs are typed `string` rather than `number`. They only ever get interpolated into a string, and a jsii `number` is a double, which risks float formatting in the Python target.

## No API break

`toSubject(): string` keeps its signature. Adding optional struct properties and a protected getter are both additive. `GithubActionsRole` and `buildConditions` needed no changes at all, since the StringEquals/StringLike selection keys off `*` and `@` is a literal in both operators.

## Error messages

Four guards throw rather than silently producing a role nobody can assume: only one ID supplied, either one supplied as an empty string, or an `@` in `owner`/`repository` that would double-apply the ID. Each message shows the concrete subject shapes instead of naming formats, and links to the README.

This also fixes a dead link that was already in `GithubActionsRole`. `github.com/blimmer/cdk-github-oidc/README.md` 404s.

## README restructure

Unrelated to the feature, but it had drifted enough to be worth fixing while I was in there:

- Every usage section was nested under `## Installation`, and the real `## Usage` was a one-line stub sitting after all of it. GitHub's outline told readers that installing the package involved subject filters and IAM grants.
- The troubleshooting list was broken by an unindented code fence, so it rendered as 1, then 1, 2, 3.
- "For Python, see below" linked to the heading it lived under.
- The security benefits bullets and the 25-line agent migration prompt now sit behind `<details>`.

## Verification

- 36 tests, 100% coverage
- Full `pnpm build` green: compile, eslint, docgen, `package:js`, `package:python`
- Synthesized a stack with previous-only, immutable-only, and mixed filters, and confirmed both the `sub` arrays and that `@` doesn't trip the `StringLike` heuristic
- Checked against this repo's live state. `gh api .../oidc/customization/sub` reports `sub_claim_prefix: "repo:blimmer/cdk-github-oidc"`, which matches the synth output. The IDs used in the docs and tests are real.

## Notes

- Conditioning on AWS STS's newer GitHub-specific keys (`repository_id`, `repository_owner_id`) is deliberately out of scope. Those keys AND together rather than OR, so they don't compose with a list of subject filters. Tracked in #25.
- A separate `chore:` commit stops jest from pegging the machine. ts-jest was building a full `aws-cdk-lib` type program in every worker. 335s down to 3s.